### PR TITLE
dns resolve amendments

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -676,8 +676,8 @@ def resolve_trusted_dc_dns():
         resolver_response = dns_resolver.resolve(TRUSTED_DOMAIN_FQDN)
         TRUSTED_DC1 = resolver_response[0].address
         TRUSTED_DC2 = resolver_response[1].address
-    except:
-        log('Error: Could not resolve Trusted DCs')
+    except Exception as e:
+        log('Error: Could not resolve Trusted DCs: %s' % e)
 
 def ipInNetwork(ip, cidrBlock):
     try:


### PR DESCRIPTION
There were two issues:

(1) Error handling for DNS resolver was wrong - I was using "KeyError"... This is fixed.
(2) When the client.py ran somewhere during the process, it could not resolve the dns, and threw error which we did not handle, so the whole program crashed and sshuttle never started. I _think_ it couldn't resolve the dns because all the setup and configs etc were probably not ready at that time to resolve the dns.

Based on the above two, I have made some changes. Instead of trying to resolve the DCs during the beginning, we do it when it is needed. Since we don't want to do it every time there is a request, I added some logic so that we only resolve once.